### PR TITLE
Route gathering and improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,11 +37,15 @@ An array of JSON documents for all applications in the configured CF environment
   "space": "space name",
   "stack": "lucid64",
   "buildpack": "https://github.com/cloudfoundry/ruby-buildpack.git",
+  "diego": false,
+  "docker": false,
+  "docker_image": null,
   "routes": [
     "app_name.yourdomain.com"
   ],
   "data_from": "unix timestamp of last update",
   "last_uploaded": "2016-02-04 15:21:25 +0000",
+  "state": "STARTED",
   "running": true,
   "instances": [
     {
@@ -76,6 +80,8 @@ An array of JSON documents for all applications in the configured CF environment
 * Memory, disk quota and usage figures are given in bytes.
 * If the buildpack is not known, the `buildpack` attribute will be `null`.
 * If the last uploaded time is not known, the `last_uploaded` attribute will be `null`.
+* The `diego` attribute is a boolean which will be `true` if the application is running on a Diego Cell, or `false` if running on a DEA Node. See the Cloud Foundry [docs](https://docs.cloudfoundry.org/concepts/diego/dea-vs-diego.html) for more information on these two architectures.
+* The `docker` attribute is a boolean which will be `true` if the application was deployed from a Docker image, or `false` if it was deployed using a buildpack. If `true`, the `docker_image` attribute will then show the Docker image used, otherwise it will be `null`.
 
 ### Organisations
 

--- a/lib/cf_light_api/lib.rb
+++ b/lib/cf_light_api/lib.rb
@@ -58,3 +58,16 @@ def format_duration(elapsed_seconds)
   hours   = elapsed_seconds / (60 * 60)
   format("%02d hrs, %02d mins, %02d secs", hours, minutes, seconds)
 end
+
+def format_routes_for_app app
+  routes = cf_rest app['entity']['routes_url']
+  routes.collect do |route|
+    host   = route['entity']['host']
+    path   = route['entity']['path']
+
+    domain = @domains.find{|a_domain| a_domain['metadata']['guid'] == route['entity']['domain_guid']}
+    domain = domain['entity']['name']
+
+    "#{host}.#{domain}#{path}"
+  end
+end

--- a/lib/cf_light_api/worker.rb
+++ b/lib/cf_light_api/worker.rb
@@ -90,15 +90,19 @@ scheduler.every UPDATE_INTERVAL, :first_in => '5s', :overlap => false, :timeout 
           running = (app['entity']['state'] == "STARTED")
 
           base_data = {
+            :buildpack     => app['entity']['buildpack'],
+            :data_from     => Time.now.to_i,
+            :diego         => app['entity']['diego'],
+            :docker        => app['entity']['docker_image'] ? true : false,
+            :docker_image  => app['entity']['docker_image'],
             :guid          => app['metadata']['guid'],
+            :last_uploaded => app['metadata']['updated_at'] ? DateTime.parse(app['metadata']['updated_at']).strftime('%Y-%m-%d %T %z') : nil,
             :name          => app['entity']['name'],
             :org           => org['entity']['name'],
             :routes        => routes,
             :space         => space['entity']['name'],
             :stack         => stack['entity']['name'],
-            :buildpack     => app['entity']['buildpack'],
-            :data_from     => Time.now.to_i,
-            :last_uploaded => app['metadata']['updated_at'] ? DateTime.parse(app['metadata']['updated_at']).strftime('%Y-%m-%d %T %z') : nil
+            :state         => app['entity']['state']
           }
 
           # Add additional data, such as instance usage statistics - but this is only possible if the instances are running.


### PR DESCRIPTION
Adds support for some additional attributes:
- diego
- docker
- docker_image

Also improves routes gathering, so an application's routes are now available even if no instances of the app are running. Previously this would not have been possible, as the routes were being retrieved from a running app instance's `uri` attribute.
