### PR TITLE
Improved exception handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .bundle/
 pkg/
+.idea/

--- a/lib/cf_light_api/worker.rb
+++ b/lib/cf_light_api/worker.rb
@@ -245,7 +245,9 @@ class CFLightAPIWorker
                :error     => nil
               }
 
-            rescue => e
+            rescue Rufus::Scheduler::TimeoutError => error
+              raise error
+            rescue StandardError => error
               # Most exceptions here will be caused by the app or one of the instances being in a non-standard state,
               # for example, trying to query an app which was present when the worker began updating, but was stopped
               # before we reached this section, so we just catch all exceptions, log the reason and move on.


### PR DESCRIPTION
Hi,

if there is a rufus scheduler timeout, the exception could also be catched in the rescue block of `formatted_apps` which result then in an invalid cached object:

```
{"buildpack": None,
  "data_from": 1511775595,
  "diego": True,
  "docker": False,
  "docker_image": None,
  "environment_variables": {},
  "error": "Rufus::Scheduler::TimeoutError",
  "guid": "000-000-000-000-000",
  "instances": [],
  "last_uploaded": "2017-11-27 07:43:06 +0000",
  "name": "app-name",
  "org": "org-name",
  "routes": [],
  "running": "error",
  "space": "staging",
  "stack": "cflinuxfs2",
  "state": "STOPPED"}
```

To avoid that, the `Rufus::Scheduler::TimeoutError` from `formatted_apps` will be caught and rethrown to be handled properly. 