### PR TITLE
Add buildpack_name field to v2 document

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ An array of JSON documents for all applications in the configured CF environment
 
 * `environment_json` - An array of environment variables exposed to this application, if enabled as documented [here](#gathering-environment-variables).
 
+* `buildpack_name` - A field containing the name of the buildpack in use. Its value is equal either to the `buildpack` attribute of the associated app or should this be `none` (autodetected buildpack) to the buildpack name as resolved from the `v2/buildpacks/<guid>` endpoint using the `detected_buildpack_guid` field as `guid`.
+
 Each document has the following structure:
 
 ```json
@@ -130,6 +132,7 @@ Each document has the following structure:
   "meta": {
     "error": false
   },
+  "buildpack_name": "buildpack_name",
   "space": "space name",
   "org": "org name"
 }
@@ -164,7 +167,7 @@ If there are no errors, the `meta` attribute will instead look like this:
 
 * Memory, disk quota and usage figures are given in bytes.
 
-* If the buildpack is not known, the `buildpack` attribute will be `null`.
+* If the buildpack is not known, the `buildpack` attribute will be `null`. However, the `buildpack_name` field will be populated using the buildpack `detected_buildpack_guid` value.
 
 * If the last uploaded time is not known, the `last_uploaded` attribute will be `null`.
 

--- a/lib/cf_light_api/worker.rb
+++ b/lib/cf_light_api/worker.rb
@@ -178,6 +178,11 @@ class CFLightAPIWorker
     @domains = cf_rest('/v2/domains?results-per-page=100')
   end
 
+  def get_buildpacks_by_guid
+    buildpacks = cf_rest('/v2/buildpacks?results-per-page=100')
+    buildpacks_by_guid = buildpacks.map { |buildpack| [buildpack['metadata']['guid'], buildpack] }.to_h
+  end
+
   def find_domain_for_route route
     return @domains.find{|a_domain| a_domain['metadata']['guid'] == route['entity']['domain_guid']}
   end
@@ -301,6 +306,7 @@ class CFLightAPIWorker
 
           @apps = cf_rest('/v2/apps?results-per-page=100&inline-relations-depth=1&include-relations=routes,stack')
           @spaces  = cf_rest('/v2/spaces?results-per-page=100')
+          @buildpacks = get_buildpacks_by_guid() # Sets @buildpacks to a map of buildpack resources indexed by guid
 
           update_domains() # Sets @domain by hitting the CF API
 
@@ -326,6 +332,16 @@ class CFLightAPIWorker
               v2_document['instances']             = []
               v2_document['routes']                = []
               v2_document['meta']                  = { 'error' => false }
+
+              # Add buildpack_name as a top level string attribute and looks it up using its guid when the buildpack field is null
+              buildpack_name = app['entity']['buildpack']
+              buildpack_guid = app['entity']['detected_buildpack_guid']
+
+              v2_document['buildpack_name'] = buildpack_name
+
+              if buildpack_name.nil? or buildpack_name.empty?
+                  v2_document['buildpack_name'] = @buildpacks[buildpack_guid]['entity']['name']
+              end
 
               # Add space, stack and org names as a top level string attribute for ease of use:
               v2_document['stack'] = app['entity']['stack']['entity']['name']

--- a/lib/cf_light_api/worker.rb
+++ b/lib/cf_light_api/worker.rb
@@ -337,10 +337,10 @@ class CFLightAPIWorker
               buildpack_name = app['entity']['buildpack']
               buildpack_guid = app['entity']['detected_buildpack_guid']
 
-              v2_document['buildpack_name'] = buildpack_name
-
-              if buildpack_name.nil? or buildpack_name.empty?
-                  v2_document['buildpack_name'] = @buildpacks[buildpack_guid]['entity']['name']
+              v2_document['buildpack_name'] = if buildpack_name.nil? or buildpack_name.empty?
+                @buildpacks[buildpack_guid]['entity']['name']
+              else
+                buildpack_name
               end
 
               # Add space, stack and org names as a top level string attribute for ease of use:


### PR DESCRIPTION
The aim of this pull request is to add a `buildpack_name` field to the v2 manifest.

When the buildpack is autodectected the `buildpack` field is set to `none` which makes
impossible to gather accurate statistics about buildpack usage.

It is though possible to get the buildpack name calling the cf api `/v2/buildpacks/<guid>` endpoint and using the guid present in the `detected_buildpack_guid`